### PR TITLE
fix(security): upgrade libexpat due to CVE-2026-32767, CVE-2026-32777, CVE-2026-32778 (fixes #49, fixes #48, fixes #47) on alpine 3.23.3

### DIFF
--- a/.github/workflows/build-and-test-new-php-versions.yml
+++ b/.github/workflows/build-and-test-new-php-versions.yml
@@ -40,14 +40,23 @@ jobs:
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            base="${{ github.event.pull_request.base.sha }}"
             head="${{ github.event.pull_request.head.sha }}"
+            base_ref="${{ github.event.pull_request.base.ref }}"
+
+            git fetch origin "$base_ref" --depth=1
+            base="$(git merge-base "origin/$base_ref" "$head")"
           else
             base="${{ github.event.before }}"
             head="${{ github.sha }}"
           fi
 
+          echo "BASE=$base"
+          echo "HEAD=$head"
+
           changed="$(git diff --name-only "$base" "$head" | grep -E '^versions/[0-9]+\.[0-9]+/[^/]+/Dockerfile$' || true)"
+
+          echo "Changed Dockerfiles:"
+          printf '%s\n' "$changed"
 
           if [ -z "${changed//[[:space:]]/}" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/hotfixes/alpine/3.23.3/CVE-2026-32767-libexpat.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-32767-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat

--- a/hotfixes/alpine/3.23.3/CVE-2026-32777-libexpat.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-32777-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat

--- a/hotfixes/alpine/3.23.3/CVE-2026-32778-libexpat.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-32778-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat


### PR DESCRIPTION
fix(security): upgrade libexpat due to CVE-2026-32767, CVE-2026-32777, CVE-2026-32778 (fixes #49, fixes #48, fixes #47) on alpine 3.23.3