### PR TITLE
fix(security): upgrade libexpat due to CVE-2026-32767, CVE-2026-32777, CVE-2026-32778 (fixes #44, fixes #45, fixes #46) on alpine 3.22.3

### DIFF
--- a/.github/workflows/build-and-test-new-php-versions.yml
+++ b/.github/workflows/build-and-test-new-php-versions.yml
@@ -53,7 +53,7 @@ jobs:
             export HEAD_SHA="${{ github.event.pull_request.head.sha }}"
             export BASE_REF="${{ github.event.pull_request.base.ref }}"
 
-            git fetch origin "$BASE_REF" --depth=1
+            git fetch origin "$BASE_REF"
             export BASE_SHA="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")"
           else
             export BASE_SHA="${{ github.event.before }}"
@@ -81,36 +81,34 @@ jobs:
                   return []
               return sorted(php_dir.glob("*/Dockerfile"))
 
-          def dockerfile_alpine_versions(dockerfile: Path):
-              text = dockerfile.read_text(encoding="utf-8", errors="ignore")
-              for line in text.splitlines():
-                  line = line.strip()
-                  if not line.upper().startswith("FROM "):
-                      continue
+def dockerfile_alpine_versions(dockerfile: Path):
+    text = dockerfile.read_text(encoding="utf-8", errors="ignore")
+    result = ("", "")
 
-                  m = re.search(r"alpine:([0-9]+\.[0-9]+\.[0-9]+)", line, re.IGNORECASE)
-                  if m:
-                      full = m.group(1)
-                      minor = ".".join(full.split(".")[:2])
-                      return full, minor
+    patterns = [
+        r"alpine:([0-9]+\.[0-9]+\.[0-9]+)",
+        r"alpine:([0-9]+\.[0-9]+)",
+        r"alpine([0-9]+\.[0-9]+\.[0-9]+)",
+        r"alpine([0-9]+\.[0-9]+)",
+    ]
 
-                  m = re.search(r"alpine:([0-9]+\.[0-9]+)", line, re.IGNORECASE)
-                  if m:
-                      minor = m.group(1)
-                      return minor, minor
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.upper().startswith("FROM "):
+            continue
 
-                  m = re.search(r"alpine([0-9]+\.[0-9]+\.[0-9]+)", line, re.IGNORECASE)
-                  if m:
-                      full = m.group(1)
-                      minor = ".".join(full.split(".")[:2])
-                      return full, minor
+        for pattern in patterns:
+            m = re.search(pattern, line, re.IGNORECASE)
+            if not m:
+                continue
 
-                  m = re.search(r"alpine([0-9]+\.[0-9]+)", line, re.IGNORECASE)
-                  if m:
-                      minor = m.group(1)
-                      return minor, minor
+            version = m.group(1)
+            parts = version.split(".")
+            minor = ".".join(parts[:2]) if len(parts) >= 2 else version
+            result = (version, minor)
+            break
 
-              return "", ""
+    return result
 
           def dockerfiles_matching_alpine(version: str):
               matched = []

--- a/hotfixes/alpine/3.22.3/CVE-2026-32767-libexpat.sh
+++ b/hotfixes/alpine/3.22.3/CVE-2026-32767-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat

--- a/hotfixes/alpine/3.22.3/CVE-2026-32777-libexpat.sh
+++ b/hotfixes/alpine/3.22.3/CVE-2026-32777-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat

--- a/hotfixes/alpine/3.22.3/CVE-2026-32778-libexpat.sh
+++ b/hotfixes/alpine/3.22.3/CVE-2026-32778-libexpat.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eux
+apk add --no-cache --upgrade libexpat


### PR DESCRIPTION
fix(security): upgrade libexpat due to CVE-2026-32767, CVE-2026-32777, CVE-2026-32778 (fixes #44, fixes #45, fixes #46) on alpine 3.22.3