### PR TITLE
hotfix(alpine-3.23.3): upgrade libpng and imagemagick packages to fix…

### DIFF
--- a/hotfixes/alpine/3.23.3/CVE-2026-28691-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-28691-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-28691-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30883-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30883-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30883-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30929-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30929-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30929-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30931-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30931-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30931-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30935-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30935-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30935-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30936-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30936-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30936-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-30937-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-30937-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-30937-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-31853-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-31853-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-31853-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-32636-imagemagick.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-32636-imagemagick.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-32636-imagemagick.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade imagemagick imagemagick-jpeg imagemagick-libs

--- a/hotfixes/alpine/3.23.3/CVE-2026-33416-libpng.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-33416-libpng.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-33416-libpng.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade libpng

--- a/hotfixes/alpine/3.23.3/CVE-2026-33636-libpng.sh
+++ b/hotfixes/alpine/3.23.3/CVE-2026-33636-libpng.sh
@@ -1,0 +1,4 @@
+# hotfixes/alpine/3.23.3/CVE-2026-33636-libpng.sh
+#!/bin/sh
+set -eu
+apk add --no-cache --upgrade libpng


### PR DESCRIPTION
… CVEs. Fixes #61 #63 #64 #65 #66 #67 #68 #69 #70 #71 #72

Add Alpine 3.23.3 hotfix scripts for libpng and ImageMagick-related vulnerabilities detected in the 8.5 CLI and FPM images.

Fixes #61
Fixes #63
Fixes #64
Fixes #65
Fixes #66
Fixes #67
Fixes #68
Fixes #69
Fixes #70
Fixes #71
Fixes #72