### PR TITLE
fix(hotfixes): resolve Alpine 3.23 CVEs (CVE-2025-68615, CVE-2026-221…

### DIFF
--- a/hotfixes/alpine/3.23.3/apk-upgrade-libpng.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-libpng.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk upgrade --no-cache libpng

--- a/hotfixes/alpine/3.23.3/apk-upgrade-musl-utils.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-musl-utils.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -eux
-apk upgrade --no-cache musl-utils
+apk upgrade --no-cache musl musl-utils

--- a/hotfixes/alpine/3.23.3/apk-upgrade-net-snmp.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-net-snmp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk upgrade --no-cache net-snmp

--- a/hotfixes/alpine/3.23.3/apk-upgrade-util-linux.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-util-linux.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk upgrade --no-cache util-linux

--- a/hotfixes/alpine/3.23.3/apk-upgrade-zlib.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-zlib.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+apk upgrade --no-cache zlib

--- a/hotfixes/alpine/3.23.3/index.yaml
+++ b/hotfixes/alpine/3.23.3/index.yaml
@@ -46,6 +46,8 @@ hotfixes:
     file: "apk-upgrade-imagemagick.sh"
     match:
       cves:
+        - "CVE-2026-33535"
+        - "CVE-2026-33536"
         - "CVE-2026-33899"
         - "CVE-2026-33900"
         - "CVE-2026-33901"
@@ -58,3 +60,29 @@ hotfixes:
         - "CVE-2026-40310"
         - "CVE-2026-40311"
         - "CVE-2026-40312"
+  - id: "apk-upgrade-net-snmp"
+    file: "apk-upgrade-net-snmp.sh"
+    match:
+      cves:
+        - "CVE-2025-68615"
+
+  - id: "apk-upgrade-zlib"
+    file: "apk-upgrade-zlib.sh"
+    match:
+      cves:
+        - "CVE-2026-22184"
+        - "CVE-2026-27171"
+
+  - id: "apk-upgrade-util-linux"
+    file: "apk-upgrade-util-linux.sh"
+    match:
+      cves:
+        - "CVE-2026-27456"
+
+  - id: "apk-upgrade-libpng"
+    file: "apk-upgrade-libpng.sh"
+    match:
+      cves:
+        - "CVE-2026-33416"
+        - "CVE-2026-33636"
+        - "CVE-2026-34757"


### PR DESCRIPTION
…84, CVE-2026-27171, CVE-2026-27456, CVE-2026-33416, CVE-2026-33535, CVE-2026-33536, CVE-2026-33636, CVE-2026-34757, CVE-2026-33899, CVE-2026-33900, CVE-2026-33901, CVE-2026-33902, CVE-2026-33905, CVE-2026-33908, CVE-2026-34238, CVE-2026-40169, CVE-2026-40183, CVE-2026-40310, CVE-2026-40311, CVE-2026-40312) closes #102 #103 #104 #105 #106 #107 #108 #109 #110 #111 #112 #113