### PR TITLE
fix(hotfix): add remediation for issues #199, #202, #207, #208

### DIFF
--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0
-# hotfix-cves: CVE-2026-47166
+# hotfix-cves: CVE-2026-46523,CVE-2026-47166
 # hotfix-packages: imagemagick-jpeg<7.1.2.23-r0,imagemagick-libs<7.1.2.23-r0,imagemagick<7.1.2.23-r0
 set -eu
 

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0
+# hotfix-cves: CVE-2026-47166
+# hotfix-packages: imagemagick-jpeg<7.1.2.23-r0,imagemagick-libs<7.1.2.23-r0,imagemagick<7.1.2.23-r0
+set -eu
+
+apk add --no-cache --upgrade 'imagemagick-jpeg>=7.1.2.23-r0' 'imagemagick-libs>=7.1.2.23-r0' 'imagemagick>=7.1.2.23-r0'

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0
-# hotfix-cves: CVE-2026-46523,CVE-2026-47166
+# hotfix-cves: CVE-2026-46523,CVE-2026-47165,CVE-2026-47166
 # hotfix-packages: imagemagick-jpeg<7.1.2.23-r0,imagemagick-libs<7.1.2.23-r0,imagemagick<7.1.2.23-r0
 set -eu
 

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0
-# hotfix-cves: CVE-2026-46523,CVE-2026-47165,CVE-2026-47166
+# hotfix-cves: CVE-2026-46520,CVE-2026-46523,CVE-2026-47165,CVE-2026-47166
 # hotfix-packages: imagemagick-jpeg<7.1.2.23-r0,imagemagick-libs<7.1.2.23-r0,imagemagick<7.1.2.23-r0
 set -eu
 


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-47166`

## Alpine versions
`3.23.4`

## Package constraints
- `imagemagick`: `7.1.2.19-r0` -> `7.1.2.23-r0`
- `imagemagick-jpeg`: `7.1.2.19-r0` -> `7.1.2.23-r0`
- `imagemagick-libs`: `7.1.2.19-r0` -> `7.1.2.23-r0`

## Generated files
- `hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.23-r0-imagemagick-jpeg-7.1.2.23-r0-imagemagick-libs-7.1.2.23-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

Fixes #208

## Remediation issues

- #208

## Remediation issues

- #202
- #208

## Remediation issues

- #202
- #207
- #208


## Remediation issues

- #199
- #202
- #207
- #208
