### PR TITLE
fix(hotfix): add remediation for issues #193, #194, #195, #196, #197

### DIFF
--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0
-# hotfix-cves: CVE-2026-42326,CVE-2026-45031,CVE-2026-45358,CVE-2026-45359
+# hotfix-cves: CVE-2026-42326,CVE-2026-45031,CVE-2026-45358,CVE-2026-45359,CVE-2026-45624
 # hotfix-packages: imagemagick-jpeg<7.1.2.22-r0,imagemagick-libs<7.1.2.22-r0,imagemagick<7.1.2.22-r0
 set -eu
 

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0
+# hotfix-cves: CVE-2026-45359
+# hotfix-packages: imagemagick-jpeg<7.1.2.22-r0,imagemagick-libs<7.1.2.22-r0,imagemagick<7.1.2.22-r0
+set -eu
+
+apk add --no-cache --upgrade 'imagemagick-jpeg>=7.1.2.22-r0' 'imagemagick-libs>=7.1.2.22-r0' 'imagemagick>=7.1.2.22-r0'

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0
-# hotfix-cves: CVE-2026-42326,CVE-2026-45358,CVE-2026-45359
+# hotfix-cves: CVE-2026-42326,CVE-2026-45031,CVE-2026-45358,CVE-2026-45359
 # hotfix-packages: imagemagick-jpeg<7.1.2.22-r0,imagemagick-libs<7.1.2.22-r0,imagemagick<7.1.2.22-r0
 set -eu
 

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0
-# hotfix-cves: CVE-2026-42326,CVE-2026-45359
+# hotfix-cves: CVE-2026-42326,CVE-2026-45358,CVE-2026-45359
 # hotfix-packages: imagemagick-jpeg<7.1.2.22-r0,imagemagick-libs<7.1.2.22-r0,imagemagick<7.1.2.22-r0
 set -eu
 

--- a/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # generated-by: create-hotfix-pr-from-issue.py
 # hotfix-id: apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0
-# hotfix-cves: CVE-2026-45359
+# hotfix-cves: CVE-2026-42326,CVE-2026-45359
 # hotfix-packages: imagemagick-jpeg<7.1.2.22-r0,imagemagick-libs<7.1.2.22-r0,imagemagick<7.1.2.22-r0
 set -eu
 


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-45359`

## Alpine versions
`3.23.4`

## Package constraints
- `imagemagick`: `7.1.2.19-r0` -> `7.1.2.22-r0`
- `imagemagick-jpeg`: `7.1.2.19-r0` -> `7.1.2.22-r0`
- `imagemagick-libs`: `7.1.2.19-r0` -> `7.1.2.22-r0`

## Generated files
- `hotfixes/alpine/3.23.4/apk-upgrade-imagemagick-7.1.2.22-r0-imagemagick-jpeg-7.1.2.22-r0-imagemagick-libs-7.1.2.22-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

Fixes #196

## Remediation issues

- #196

## Remediation issues

- #193
- #196

## Remediation issues

- #193
- #195
- #196

## Remediation issues

- #193
- #194
- #195
- #196


## Remediation issues

- #193
- #194
- #195
- #196
- #197
