### PR TITLE
fix(hotfix): add remediation for issues #213

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-libssh2-1.11.1-r1.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-libssh2-1.11.1-r1.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libssh2-1.11.1-r1
+# hotfix-cves: CVE-2026-7598
+# hotfix-packages: libssh2<1.11.1-r1
+set -eu
+
+apk add --no-cache --upgrade 'libssh2>=1.11.1-r1'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-7598`

## Alpine versions
`3.22.4`

## Package constraints
- `libssh2`: `1.11.1-r0` -> `1.11.1-r1`

## Generated files
- `hotfixes/alpine/3.22.4/apk-upgrade-libssh2-1.11.1-r1.sh`

After merge, the regular image build will verify whether the CVE is gone.

Fixes #213

## Remediation issues

- #213
