### PR TITLE
fix(hotfix): add remediation for issues #215

### DIFF
--- a/hotfixes/alpine/3.23.3/apk-upgrade-libssh2-1.11.1-r2.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-libssh2-1.11.1-r2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libssh2-1.11.1-r2
+# hotfix-cves: CVE-2026-7598
+# hotfix-packages: libssh2<1.11.1-r2
+set -eu
+
+apk add --no-cache --upgrade 'libssh2>=1.11.1-r2'

--- a/hotfixes/alpine/3.23.4/apk-upgrade-libssh2-1.11.1-r2.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-libssh2-1.11.1-r2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libssh2-1.11.1-r2
+# hotfix-cves: CVE-2026-7598
+# hotfix-packages: libssh2<1.11.1-r2
+set -eu
+
+apk add --no-cache --upgrade 'libssh2>=1.11.1-r2'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-7598`

## Alpine versions
`3.23.3`, `3.23.4`

## Package constraints
- `libssh2`: `1.11.1-r1` -> `1.11.1-r2`

## Generated files
- `hotfixes/alpine/3.23.3/apk-upgrade-libssh2-1.11.1-r2.sh`
- `hotfixes/alpine/3.23.4/apk-upgrade-libssh2-1.11.1-r2.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #215
