### PR TITLE
fix(hotfix): add remediation for issues #212

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-libxml2-2.13.9-r1.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-libxml2-2.13.9-r1.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libxml2-2.13.9-r1
+# hotfix-cves: CVE-2026-6732
+# hotfix-packages: libxml2<2.13.9-r1
+set -eu
+
+apk add --no-cache --upgrade 'libxml2>=2.13.9-r1'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-6732`

## Alpine versions
`3.22.4`

## Package constraints
- `libxml2`: `2.13.9-r0` -> `2.13.9-r1`

## Generated files
- `hotfixes/alpine/3.22.4/apk-upgrade-libxml2-2.13.9-r1.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #212
