### PR TITLE
fix(hotfix): add remediation for issues #231, #232, #233, #234, #235, #236, #237, #238, #239, #240

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0
+# hotfix-cves: CVE-2026-34182,CVE-2026-34183,CVE-2026-42764,CVE-2026-45445,CVE-2026-45447
+# hotfix-packages: libcrypto3<3.5.7-r0,libssl3<3.5.7-r0,openssl<3.5.7-r0
+set -eu
+
+apk add --no-cache --upgrade 'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' 'openssl>=3.5.7-r0'

--- a/hotfixes/alpine/3.23.4/apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0.sh
+++ b/hotfixes/alpine/3.23.4/apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0
+# hotfix-cves: CVE-2026-34182,CVE-2026-34183,CVE-2026-42764,CVE-2026-45445,CVE-2026-45447
+# hotfix-packages: libcrypto3<3.5.7-r0,libssl3<3.5.7-r0,openssl<3.5.7-r0
+set -eu
+
+apk add --no-cache --upgrade 'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' 'openssl>=3.5.7-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-45447`

## Alpine versions
`3.23.4`

## Package constraints
- `libcrypto3`: `3.5.6-r0` -> `3.5.7-r0`
- `libssl3`: `3.5.6-r0` -> `3.5.7-r0`
- `openssl`: `3.5.6-r0` -> `3.5.7-r0`

## Generated files
- `hotfixes/alpine/3.23.4/apk-upgrade-libcrypto3-3.5.7-r0-libssl3-3.5.7-r0-openssl-3.5.7-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #231
- #232
- #233
- #234
- #235
- #236
- #237
- #238
- #239
- #240
