### PR TITLE
fix(hotfix): add remediation for issues #243

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-libexpat-2.8.1-r0.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-libexpat-2.8.1-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libexpat-2.8.1-r0
+# hotfix-cves: CVE-2026-45186
+# hotfix-packages: libexpat<2.8.1-r0
+set -eu
+
+apk add --no-cache --upgrade 'libexpat>=2.8.1-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-45186`

## Alpine versions
`3.22.4`

## Package constraints
- `libexpat`: `2.7.5-r0` -> `2.8.1-r0`

## Generated files
- `hotfixes/alpine/3.22.4/apk-upgrade-libexpat-2.8.1-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #243
