### PR TITLE
fix(hotfix): add remediation for issues #245, #246

### DIFF
--- a/hotfixes/alpine/3.24.1/apk-upgrade-libssh2-1.11.1-r3.sh
+++ b/hotfixes/alpine/3.24.1/apk-upgrade-libssh2-1.11.1-r3.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libssh2-1.11.1-r3
+# hotfix-cves: CVE-2026-55199,CVE-2026-55200
+# hotfix-packages: libssh2<1.11.1-r3
+set -eu
+
+apk add --no-cache --upgrade 'libssh2>=1.11.1-r3'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-55200`

## Alpine versions
`3.24.1`

## Package constraints
- `libssh2`: `1.11.1-r2` -> `1.11.1-r3`

## Generated files
- `hotfixes/alpine/3.24.1/apk-upgrade-libssh2-1.11.1-r3.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #245
- #246
