### PR TITLE
fix(hotfix): add remediation for issues #248, #249, #250, #251, #252, #253, #254, #255, #256

### DIFF
--- a/hotfixes/alpine/3.24.1/apk-upgrade-libexpat-2.8.2-r0.sh
+++ b/hotfixes/alpine/3.24.1/apk-upgrade-libexpat-2.8.2-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-libexpat-2.8.2-r0
+# hotfix-cves: CVE-2026-50219,CVE-2026-56132,CVE-2026-56403,CVE-2026-56404,CVE-2026-56405,CVE-2026-56406,CVE-2026-56410,CVE-2026-56411,CVE-2026-56412
+# hotfix-packages: libexpat<2.8.2-r0
+set -eu
+
+apk add --no-cache --upgrade 'libexpat>=2.8.2-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-56412`

## Alpine versions
`3.24.1`

## Package constraints
- `libexpat`: `2.8.1-r0` -> `2.8.2-r0`

## Generated files
- `hotfixes/alpine/3.24.1/apk-upgrade-libexpat-2.8.2-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #248
- #249
- #250
- #251
- #252
- #253
- #254
- #255
- #256
