### PR TITLE
fix(hotfix): add remediation for issues #259, #260, #261, #262

### DIFF
--- a/hotfixes/alpine/3.24.1/apk-upgrade-curl-8.21.0-r0-libcurl-8.21.0-r0.sh
+++ b/hotfixes/alpine/3.24.1/apk-upgrade-curl-8.21.0-r0-libcurl-8.21.0-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-curl-8.21.0-r0-libcurl-8.21.0-r0
+# hotfix-cves: CVE-2026-11856,CVE-2026-8925,CVE-2026-8927,CVE-2026-9079
+# hotfix-packages: curl<8.21.0-r0,libcurl<8.21.0-r0
+set -eu
+
+apk add --no-cache --upgrade 'curl>=8.21.0-r0' 'libcurl>=8.21.0-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-9079`

## Alpine versions
`3.24.1`

## Package constraints
- `curl`: `8.20.0-r1` -> `8.21.0-r0`
- `libcurl`: `8.20.0-r1` -> `8.21.0-r0`

## Generated files
- `hotfixes/alpine/3.24.1/apk-upgrade-curl-8.21.0-r0-libcurl-8.21.0-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #259
- #260
- #261
- #262
