### PR TITLE
fix(hotfix): add remediation for issues #265

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-c-ares-1.34.8-r0.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-c-ares-1.34.8-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-c-ares-1.34.8-r0
+# hotfix-cves: CVE-2026-33630
+# hotfix-packages: c-ares<1.34.8-r0
+set -eu
+
+apk add --no-cache --upgrade 'c-ares>=1.34.8-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-33630`

## Alpine versions
`3.22.4`

## Package constraints
- `c-ares`: `1.34.6-r0` -> `1.34.8-r0`

## Generated files
- `hotfixes/alpine/3.22.4/apk-upgrade-c-ares-1.34.8-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #265
