### PR TITLE
fix(hotfix): add remediation for issues #267

### DIFF
--- a/hotfixes/alpine/3.22.4/apk-upgrade-curl-8.14.1-r3-libcurl-8.14.1-r3.sh
+++ b/hotfixes/alpine/3.22.4/apk-upgrade-curl-8.14.1-r3-libcurl-8.14.1-r3.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-curl-8.14.1-r3-libcurl-8.14.1-r3
+# hotfix-cves: CVE-2026-5545
+# hotfix-packages: curl<8.14.1-r3,libcurl<8.14.1-r3
+set -eu
+
+apk add --no-cache --upgrade 'curl>=8.14.1-r3' 'libcurl>=8.14.1-r3'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-5545`

## Alpine versions
`3.22.4`

## Package constraints
- `curl`: `8.14.1-r2` -> `8.14.1-r3`
- `libcurl`: `8.14.1-r2` -> `8.14.1-r3`

## Generated files
- `hotfixes/alpine/3.22.4/apk-upgrade-curl-8.14.1-r3-libcurl-8.14.1-r3.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #267
