### PR TITLE
fix(hotfix): add remediation for issues #271, #272, #273, #274

### DIFF
--- a/hotfixes/alpine/3.24.1/apk-upgrade-imagemagick-7.1.2.25-r0-imagemagick-jpeg-7.1.2.25-r0-imagemagick-libs-7.1.2.25-r0.sh
+++ b/hotfixes/alpine/3.24.1/apk-upgrade-imagemagick-7.1.2.25-r0-imagemagick-jpeg-7.1.2.25-r0-imagemagick-libs-7.1.2.25-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-imagemagick-7.1.2.25-r0-imagemagick-jpeg-7.1.2.25-r0-imagemagick-libs-7.1.2.25-r0
+# hotfix-cves: CVE-2026-53460,CVE-2026-53461,CVE-2026-53463,CVE-2026-53465
+# hotfix-packages: imagemagick-jpeg<7.1.2.25-r0,imagemagick-libs<7.1.2.25-r0,imagemagick<7.1.2.25-r0
+set -eu
+
+apk add --no-cache --upgrade 'imagemagick-jpeg>=7.1.2.25-r0' 'imagemagick-libs>=7.1.2.25-r0' 'imagemagick>=7.1.2.25-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-53465`

## Alpine versions
`3.24.1`

## Package constraints
- `imagemagick`: `7.1.2.24-r0` -> `7.1.2.25-r0`
- `imagemagick-jpeg`: `7.1.2.24-r0` -> `7.1.2.25-r0`
- `imagemagick-libs`: `7.1.2.24-r0` -> `7.1.2.25-r0`

## Generated files
- `hotfixes/alpine/3.24.1/apk-upgrade-imagemagick-7.1.2.25-r0-imagemagick-jpeg-7.1.2.25-r0-imagemagick-libs-7.1.2.25-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #271
- #272
- #273
- #274
