### PR TITLE
fix(hotfix): add remediation for issues #286, #287

### DIFF
--- a/hotfixes/alpine/3.23.3/apk-upgrade-sqlite-libs-3.53.4-r0.sh
+++ b/hotfixes/alpine/3.23.3/apk-upgrade-sqlite-libs-3.53.4-r0.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# generated-by: create-hotfix-pr-from-issue.py
+# hotfix-id: apk-upgrade-sqlite-libs-3.53.4-r0
+# hotfix-cves: CVE-2026-11822,CVE-2026-11824
+# hotfix-packages: sqlite-libs<3.53.4-r0
+set -eu
+
+apk add --no-cache --upgrade 'sqlite-libs>=3.53.4-r0'


### PR DESCRIPTION
Adds Alpine hotfix remediation generated from these security issues:

## CVEs
`CVE-2026-11824`

## Alpine versions
`3.23.3`

## Package constraints
- `sqlite-libs`: `3.51.2-r0` -> `3.53.4-r0`

## Generated files
- `hotfixes/alpine/3.23.3/apk-upgrade-sqlite-libs-3.53.4-r0.sh`

After merge, the regular image build will verify whether the CVE is gone.

## Remediation issues

- #286
- #287
